### PR TITLE
Patternised the first round of classes and upgraded to ODK 1.2.19

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -1,7 +1,7 @@
 # ----------------------------------------
 # Makefile for mp
 # Generated using ontology-starter-kit
-# ODK Version: v1.2.18
+# ODK Version: v1.2.19
 # ----------------------------------------
 # <do not edit above this line>
 
@@ -26,7 +26,7 @@ REPORT_FAIL_ON =            none
 OBO_FORMAT_OPTIONS =        
 SPARQL_VALIDATION_CHECKS =  equivalent-classes trailing-whitespace owldef-self-reference xref-syntax nolabels
 SPARQL_EXPORTS =            basic-report class-count-by-prefix edges xrefs obsoletes synonyms
-ODK_VERSION =               v1.2.18
+ODK_VERSION =               v1.2.19
 
 TODAY ?= $(shell date +%Y-%m-%d)
 OBODATE ?= $(shell date +'%d:%m:%Y %H:%M')
@@ -48,7 +48,7 @@ RELEASE_ARTEFACTS = $(sort  base simple-non-classified full base full)
 .PHONY: .FORCE
 all: odkversion all_imports patterns all_main all_subsets sparql_test all_reports all_assets
 test: odkversion sparql_test all_reports
-	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed asserted-only --output test.owl && rm test.owl && echo "Success"
+	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed asserted-only --exclude-tautologies structural --output test.owl && rm test.owl && echo "Success"
 
 odkversion:
 	echo "ODK Makefile version: $(ODK_VERSION) (this is the version of the ODK with which this Makefile was generated, not the version of the ODK you are running)" &&\
@@ -218,7 +218,7 @@ $(ONT)-base.owl: $(SRC) $(OTHER_SRC)
 # Full: The full artefacts with imports merged, reasoned
 $(ONT)-full.owl: $(SRC) $(OTHER_SRC)
 	$(ROBOT) merge --input $< \
-		reason --reasoner ELK --equivalent-classes-allowed asserted-only \
+		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
 		relax \
 		reduce -r ELK \
 		annotate --ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ --output $@.tmp.owl && mv $@.tmp.owl $@
@@ -279,8 +279,7 @@ imports/%_import.json: imports/%_import.owl
 
 IMP=true # Global parameter to bypass import generation
 MIR=true # Global parameter to bypass mirror generation
-
-
+PAT=true # Global parameter to bypass pattern generation
 
 ## ONTOLOGY: nbo
 ## Copy of nbo is re-downloaded whenever source changes
@@ -297,7 +296,7 @@ mirror/nbo.owl: mirror/nbo.trigger
 mirror/pr.trigger: $(SRC)
 
 mirror/pr.owl: mirror/pr.trigger
-	@if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(ROBOT) convert -I $(URIBASE)/pr.owl -o $@.tmp.owl && mv $@.tmp.owl $@; fi
+	@if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(ROBOT) convert -I http://purl.obolibrary.org/obo/pr.owl.gz -o $@.tmp.owl && mv $@.tmp.owl $@; fi
 
 .PRECIOUS: mirror/%.owl
 
@@ -337,7 +336,7 @@ mirror/ro.owl: mirror/ro.trigger
 mirror/chebi.trigger: $(SRC)
 
 mirror/chebi.owl: mirror/chebi.trigger
-	@if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(ROBOT) convert -I $(URIBASE)/chebi.owl -o $@.tmp.owl && mv $@.tmp.owl $@; fi
+	@if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(ROBOT) convert -I http://purl.obolibrary.org/obo/chebi.owl.gz -o $@.tmp.owl && mv $@.tmp.owl $@; fi
 
 .PRECIOUS: mirror/%.owl
 
@@ -406,7 +405,7 @@ sparql_test: $(SRC)
 # ROBOT report
 # ----------------------------------------
 reports/%-obo-report.tsv: %
-	$(ROBOT) report -i $< --fail-on $(REPORT_FAIL_ON) -o $@
+	$(ROBOT) report -i $< --fail-on $(REPORT_FAIL_ON) --print 5 -o $@
 
 # ----------------------------------------
 # Sparql queries: Exports
@@ -440,16 +439,17 @@ patterns: all_imports $(PATTERNDIR)/pattern.owl $(PATTERNDIR)/definitions.owl
 pattern_clean:
 	echo "Not implemented"
 
-pattern_schema_checks: $(PATTERNDIR)/dosdp-patterns
-	simple_pattern_tester.py $(PATTERNDIR)/dosdp-patterns/ # 2>&1 | tee $@
+pattern_schema_checks: update_patterns
+	@if [ $(PAT) = true ]; then $(PATTERN_TESTER) $(PATTERNDIR)/dosdp-patterns/; fi
+
 
 #This command is a workaround for the absence of -N and -i in wget of alpine (the one ODK depend on now). It downloads all patterns specified in external.txt
-$(PATTERNDIR)/dosdp-patterns: .FORCE
-	cat $(PATTERNDIR)/dosdp-patterns/external.txt | sed 's!.*/!!' | sed 's! !!g' |  xargs -I{} rm -f $(PATTERNDIR)/dosdp-patterns/{}
-	cat $(PATTERNDIR)/dosdp-patterns/external.txt | sed 's! !!g' | xargs -I{} wget -q {} -P $(PATTERNDIR)/dosdp-patterns
+update_patterns: .FORCE
+	wget -i $(PATTERNDIR)/dosdp-patterns/external.txt --backups=1 -P $(PATTERNDIR)/dosdp-patterns
+	rm $(PATTERNDIR)/dosdp-patterns/*.yaml.1
 
-$(PATTERNDIR)/pattern.owl: pattern_schema_checks $(PATTERNDIR)/dosdp-patterns
-	$(DOSDPT) prototype --obo-prefixes --template=$(PATTERNDIR)/dosdp-patterns --outfile=$@
+$(PATTERNDIR)/pattern.owl: pattern_schema_checks update_patterns
+	@if [ $(PAT) = true ]; then $(DOSDPT) prototype --obo-prefixes --template=$(PATTERNDIR)/dosdp-patterns --outfile=$@; fi
 
 individual_patterns_default := $(patsubst %.tsv, $(PATTERNDIR)/data/default/%.ofn, $(notdir $(wildcard $(PATTERNDIR)/data/default/*.tsv)))
 pattern_term_lists_default := $(patsubst %.tsv, $(PATTERNDIR)/data/default/%.txt, $(notdir $(wildcard $(PATTERNDIR)/data/default/*.tsv)))
@@ -459,26 +459,25 @@ pattern_term_lists_default := $(patsubst %.tsv, $(PATTERNDIR)/data/default/%.txt
 
 
 # Generating the individual pattern modules and merging them into definitions.owl
-$(PATTERNDIR)/definitions.owl: prepare_patterns $(individual_patterns_default)  
-	$(ROBOT) merge $(addprefix -i , $(individual_patterns_default))   annotate --ontology-iri $(ONTBASE)/patterns/definitions.owl  --version-iri $(ONTBASE)/releases/$(TODAY)/patterns/definitions.owl -o definitions.ofn &&\
-	mv definitions.ofn $@
+$(PATTERNDIR)/definitions.owl: prepare_patterns update_patterns $(individual_patterns_default)  
+	@if [ $(PAT) = true ]; then $(ROBOT) merge $(addprefix -i , $(individual_patterns_default))   annotate --ontology-iri $(ONTBASE)/patterns/definitions.owl  --version-iri $(ONTBASE)/releases/$(TODAY)/patterns/definitions.owl -o definitions.ofn && mv definitions.ofn $@; fi
 
 $(PATTERNDIR)/data/default/%.ofn: $(PATTERNDIR)/data/default/%.tsv $(PATTERNDIR)/dosdp-patterns/%.yaml $(SRC) all_imports .FORCE
-	dosdp-tools generate --catalog=catalog-v001.xml --infile=$< --template=$(word 2, $^) --ontology=$(word 3, $^) --obo-prefixes=true --outfile=$@
+	@if [ $(PAT) = true ]; then $(DOSDPT) generate --catalog=catalog-v001.xml --infile=$< --template=$(word 2, $^) --ontology=$(word 3, $^) --obo-prefixes=true --restrict-axioms-to=logical --outfile=$@; fi
 
 
 
 
 
-# Generating the seed file from all the TSVs
+# Generating the seed file from all the TSVs. If Pattern generation is deactivated, we still extract a seed from definitions.owl
 $(PATTERNDIR)/all_pattern_terms.txt: $(pattern_term_lists_default)   $(PATTERNDIR)/pattern_owl_seed.txt
-	cat $^ | sort | uniq > $@
+	@if [ $(PAT) = true ]; then cat $^ | sort | uniq > $@; else $(ROBOT) query --use-graphs true -f csv -i ../patterns/definitions.owl --query ../sparql/terms.sparql $@; fi
 
 $(PATTERNDIR)/pattern_owl_seed.txt: $(PATTERNDIR)/pattern.owl
-	@if [ $(IMP) = true ]; then $(ROBOT) query --use-graphs true -f csv -i $< --query ../sparql/terms.sparql $@; fi
+	@if [ $(PAT) = true ]; then $(ROBOT) query --use-graphs true -f csv -i $< --query ../sparql/terms.sparql $@; fi
 
 $(PATTERNDIR)/data/default/%.txt: $(PATTERNDIR)/dosdp-patterns/%.yaml $(PATTERNDIR)/data/default/%.tsv .FORCE
-	dosdp-tools terms --infile=$(word 2, $^) --template=$< --obo-prefixes=true --outfile=$@
+	@if [ $(PAT) = true ]; then $(DOSDPT) terms --infile=$(word 2, $^) --template=$< --obo-prefixes=true --outfile=$@; fi
 
 .PHONY: prepare_patterns
 prepare_patterns:

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
+    <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
         <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/imports/chebi_import.owl" uri="imports/chebi_import.owl"/>
         <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/imports/cl_import.owl" uri="imports/cl_import.owl"/>
         <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/imports/go_import.owl" uri="imports/go_import.owl"/>
@@ -10,6 +10,6 @@
         <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/imports/pr_import.owl" uri="imports/pr_import.owl"/>
         <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/imports/ro_import.owl" uri="imports/ro_import.owl"/>
         <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/imports/uberon_import.owl" uri="imports/uberon_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/patterns/definitions.owl" uri="patterns/definitions.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/patterns/definitions.owl" uri="../patterns/definitions.owl"/>
       </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -10,5 +10,6 @@
         <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/imports/pr_import.owl" uri="imports/pr_import.owl"/>
         <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/imports/ro_import.owl" uri="imports/ro_import.owl"/>
         <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/imports/uberon_import.owl" uri="imports/uberon_import.owl"/>
-    </group>
+        <uri id="Automatically generated entry, Timestamp=1569338358152" name="http://purl.obolibrary.org/obo/mp/patterns/definitions.owl" uri="patterns/definitions.owl"/>
+      </group>
 </catalog>

--- a/src/patterns/definitions.owl
+++ b/src/patterns/definitions.owl
@@ -7,6 +7,921 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/mp/patterns/definitions.owl>
-<http://purl.obolibrary.org/obo/mp/releases/2019-08-09/patterns/definitions.owl>
+<http://purl.obolibrary.org/obo/mp/releases/2019-10-10/patterns/definitions.owl>
+
+Declaration(Class(<http://purl.obolibrary.org/obo/GO_0032941>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0000249>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0000609>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0000649>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001059>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001221>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001345>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001348>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001533>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001544>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001545>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001663>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001790>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001881>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001908>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001919>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001983>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0001985>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002106>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002133>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002136>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002139>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002164>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002269>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002693>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002876>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002909>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0002991>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003205>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003252>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003431>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003438>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003507>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003589>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003607>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003633>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003643>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003644>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003698>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003699>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003762>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003763>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003776>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0003878>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0004183>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0004264>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0004742>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0004833>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0004884>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0004894>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0004895>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0004970>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005085>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005167>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005253>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005310>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005423>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005501>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005502>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005548>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005595>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005645>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005646>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005647>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005666>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0005670>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0006088>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0006175>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0006228>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0006276>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0006277>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0008737>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0008864>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0008932>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0009064>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0009164>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0009201>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0009212>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0009359>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0009417>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0009418>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0009671>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010038>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010147>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010148>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010154>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010155>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010156>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010172>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010368>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010386>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010680>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0010746>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011194>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011304>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011346>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011363>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011422>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011423>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011698>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011728>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011781>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011844>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0011926>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0012006>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0012018>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0012020>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0012028>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0012506>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0012507>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0012508>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013295>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013300>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013319>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013326>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013327>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013366>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013368>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013391>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013450>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013455>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013532>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013534>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013535>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013536>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013555>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013556>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013557>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013559>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013561>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013567>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013570>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013585>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013586>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013596>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0013902>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0014030>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0014031>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0014047>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0014078>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0014184>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0014185>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0014190>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0014200>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0014201>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0020371>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0020412>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0020517>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0020860>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0030140>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0030144>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0030466>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0030584>))
+Declaration(Class(<http://purl.obolibrary.org/obo/MP_0030802>))
+Declaration(Class(<http://purl.obolibrary.org/obo/PATO_0000460>))
+Declaration(Class(<http://purl.obolibrary.org/obo/PATO_0001236>))
+Declaration(Class(<http://purl.obolibrary.org/obo/PATO_0001509>))
+Declaration(Class(<http://purl.obolibrary.org/obo/PATO_0001623>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000007>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000011>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000012>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000013>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000014>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000016>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000017>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000019>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000043>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000056>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000074>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000079>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000120>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000160>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000305>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000325>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000362>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000414>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000473>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000474>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000478>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000941>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000946>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000955>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000964>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000990>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000992>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000995>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000996>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000997>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0000998>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001003>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001004>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001007>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001008>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001013>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001016>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001033>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001044>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001132>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001133>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001134>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001213>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001225>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001228>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001231>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001232>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001241>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001255>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001264>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001277>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001295>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001301>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001347>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001348>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001434>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001577>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001629>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001630>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001690>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001736>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001750>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001769>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001776>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001782>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001817>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001818>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001820>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001821>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001829>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001830>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001831>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001832>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001833>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001872>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001890>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001891>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001898>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001905>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001911>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001962>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001981>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001987>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001997>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002028>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002037>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002046>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002073>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002106>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002107>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002110>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002113>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002123>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002124>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002255>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002365>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002366>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002367>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002368>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002369>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002370>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002390>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002394>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002405>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002410>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002421>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002423>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0002530>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0003210>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0003244>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0003889>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0003937>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0004053>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0004103>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0004237>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0004535>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0004550>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0004681>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0004802>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0004877>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0005057>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0005291>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0005398>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0005399>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0005725>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0006003>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0006007>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0006558>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0008852>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0008974>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0010133>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0010243>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0011148>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0012344>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UBERON_0036145>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000051>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000066>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0000052>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0002573>))
+
+############################
+#   Classes
+############################
+
+# Class: <http://purl.obolibrary.org/obo/MP_0000249> (<http://purl.obolibrary.org/obo/MP_0000249>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0000249> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001981>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0000609> (<http://purl.obolibrary.org/obo/MP_0000609>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0000609> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002107>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0000649> (<http://purl.obolibrary.org/obo/MP_0000649>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0000649> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001821>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001059> (<http://purl.obolibrary.org/obo/MP_0001059>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001059> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000941>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001221> (<http://purl.obolibrary.org/obo/MP_0001221>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001221> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001003>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001345> (<http://purl.obolibrary.org/obo/MP_0001345>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001345> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001818>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001348> (<http://purl.obolibrary.org/obo/MP_0001348>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001348> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001817>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001533> (<http://purl.obolibrary.org/obo/MP_0001533>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001533> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001434>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001544> (<http://purl.obolibrary.org/obo/MP_0001544>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001544> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0004535>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001545> (<http://purl.obolibrary.org/obo/MP_0001545>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001545> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002390>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001663> (<http://purl.obolibrary.org/obo/MP_0001663>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001663> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001790> (<http://purl.obolibrary.org/obo/MP_0001790>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001790> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002405>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001881> (<http://purl.obolibrary.org/obo/MP_0001881>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001881> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001911>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001908> (<http://purl.obolibrary.org/obo/MP_0001908>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001908> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001872>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001919> (<http://purl.obolibrary.org/obo/MP_0001919>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001919> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000990>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001983> (<http://purl.obolibrary.org/obo/MP_0001983>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001983> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0005725>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0001985> (<http://purl.obolibrary.org/obo/MP_0001985>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0001985> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001033>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002106> (<http://purl.obolibrary.org/obo/MP_0002106>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001630>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002133> (<http://purl.obolibrary.org/obo/MP_0002133>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001004>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002136> (<http://purl.obolibrary.org/obo/MP_0002136>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002136> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002113>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002139> (<http://purl.obolibrary.org/obo/MP_0002139>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002139> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002423>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002164> (<http://purl.obolibrary.org/obo/MP_0002164>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002164> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002530>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002269> (<http://purl.obolibrary.org/obo/MP_0002269>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002269> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001630>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002693> (<http://purl.obolibrary.org/obo/MP_0002693>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002693> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001264>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002876> (<http://purl.obolibrary.org/obo/MP_0002876>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002876> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002046>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002909> (<http://purl.obolibrary.org/obo/MP_0002909>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002909> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002369>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0002991> (<http://purl.obolibrary.org/obo/MP_0002991>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0002991> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001821>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003205> (<http://purl.obolibrary.org/obo/MP_0003205>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003205> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000473>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003252> (<http://purl.obolibrary.org/obo/MP_0003252>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002394>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003431> (<http://purl.obolibrary.org/obo/MP_0003431>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003431> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001132>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003438> (<http://purl.obolibrary.org/obo/MP_0003438>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003438> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001629>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003507> (<http://purl.obolibrary.org/obo/MP_0003507>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003507> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000992>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003589> (<http://purl.obolibrary.org/obo/MP_0003589>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003589> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000056>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003607> (<http://purl.obolibrary.org/obo/MP_0003607>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003607> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002367>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003633> (<http://purl.obolibrary.org/obo/MP_0003633>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003633> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001016>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003643> (<http://purl.obolibrary.org/obo/MP_0003643>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003643> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002106>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003644> (<http://purl.obolibrary.org/obo/MP_0003644>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003644> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002370>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003698> (<http://purl.obolibrary.org/obo/MP_0003698>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003698> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000079>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003699> (<http://purl.obolibrary.org/obo/MP_0003699>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003699> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000474>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003762> (<http://purl.obolibrary.org/obo/MP_0003762>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003762> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0005057>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003763> (<http://purl.obolibrary.org/obo/MP_0003763>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002370>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003776> (<http://purl.obolibrary.org/obo/MP_0003776>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003776> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001833>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0003878> (<http://purl.obolibrary.org/obo/MP_0003878>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0003878> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001690>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0004183> (<http://purl.obolibrary.org/obo/MP_0004183>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0004183> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000013>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0004264> (<http://purl.obolibrary.org/obo/MP_0004264>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0004264> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000478>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0004742> (<http://purl.obolibrary.org/obo/MP_0004742>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0004742> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0004681>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0004833> (<http://purl.obolibrary.org/obo/MP_0004833>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0004833> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000992>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0004884> (<http://purl.obolibrary.org/obo/MP_0004884>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0004884> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000473>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0004894> (<http://purl.obolibrary.org/obo/MP_0004894>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0004894> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000995>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0004895> (<http://purl.obolibrary.org/obo/MP_0004895>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0004895> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000996>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0004970> (<http://purl.obolibrary.org/obo/MP_0004970>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0004970> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002113>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005085> (<http://purl.obolibrary.org/obo/MP_0005085>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005085> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002110>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005167> (<http://purl.obolibrary.org/obo/MP_0005167>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005167> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000120>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005253> (<http://purl.obolibrary.org/obo/MP_0005253>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005253> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000019>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005310> (<http://purl.obolibrary.org/obo/MP_0005310>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005310> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001044>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005423> (<http://purl.obolibrary.org/obo/MP_0005423>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005423> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000012>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005501> (<http://purl.obolibrary.org/obo/MP_0005501>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005501> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000014>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005502> (<http://purl.obolibrary.org/obo/MP_0005502>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001008>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005548> (<http://purl.obolibrary.org/obo/MP_0005548>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005548> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001782>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005595> (<http://purl.obolibrary.org/obo/MP_0005595>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005595> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0004237>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005645> (<http://purl.obolibrary.org/obo/MP_0005645>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005645> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001898>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005646> (<http://purl.obolibrary.org/obo/MP_0005646>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005646> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005647> (<http://purl.obolibrary.org/obo/MP_0005647>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005647> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0003937>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005666> (<http://purl.obolibrary.org/obo/MP_0005666>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005666> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001013>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0005670> (<http://purl.obolibrary.org/obo/MP_0005670>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0005670> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001347>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0006088> (<http://purl.obolibrary.org/obo/MP_0006088>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0006088> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0003210>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0006175> (<http://purl.obolibrary.org/obo/MP_0006175>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0006175> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001776>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0006228> (<http://purl.obolibrary.org/obo/MP_0006228>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0006228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001769>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0006276> (<http://purl.obolibrary.org/obo/MP_0006276>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0006276> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002410>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0006277> (<http://purl.obolibrary.org/obo/MP_0006277>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0006277> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000011>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0008737> (<http://purl.obolibrary.org/obo/MP_0008737>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0008737> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002106>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0008864> (<http://purl.obolibrary.org/obo/MP_0008864>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0008864> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/GO_0032941> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000066> <http://purl.obolibrary.org/obo/UBERON_0000160>))) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0008932> (<http://purl.obolibrary.org/obo/MP_0008932>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0008932> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0005291>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0009064> (<http://purl.obolibrary.org/obo/MP_0009064>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0009064> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0003889>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0009164> (<http://purl.obolibrary.org/obo/MP_0009164>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0009164> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000017>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0009201> (<http://purl.obolibrary.org/obo/MP_0009201>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0009201> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0004053>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0009212> (<http://purl.obolibrary.org/obo/MP_0009212>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0009212> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000997>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0009359> (<http://purl.obolibrary.org/obo/MP_0009359>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0009359> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001295>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0009417> (<http://purl.obolibrary.org/obo/MP_0009417>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0009417> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001134>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0009418> (<http://purl.obolibrary.org/obo/MP_0009418>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0009418> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001133>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0009671> (<http://purl.obolibrary.org/obo/MP_0009671>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0009671> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000995>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010038> (<http://purl.obolibrary.org/obo/MP_0010038>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010038> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001987>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010147> (<http://purl.obolibrary.org/obo/MP_0010147>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010147> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000016>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010148> (<http://purl.obolibrary.org/obo/MP_0010148>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010148> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000017>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010154> (<http://purl.obolibrary.org/obo/MP_0010154>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010154> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0004550>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010155> (<http://purl.obolibrary.org/obo/MP_0010155>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010155> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000160>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010156> (<http://purl.obolibrary.org/obo/MP_0010156>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010156> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001241>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010172> (<http://purl.obolibrary.org/obo/MP_0010172>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010172> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0003244>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010368> (<http://purl.obolibrary.org/obo/MP_0010368>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010368> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0006558>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010386> (<http://purl.obolibrary.org/obo/MP_0010386>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010386> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001255>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010680> (<http://purl.obolibrary.org/obo/MP_0010680>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010680> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0006003>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0010746> (<http://purl.obolibrary.org/obo/MP_0010746>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0010746> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0006007>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011194> (<http://purl.obolibrary.org/obo/MP_0011194>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011194> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002073>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011304> (<http://purl.obolibrary.org/obo/MP_0011304>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001228>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011346> (<http://purl.obolibrary.org/obo/MP_0011346>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011346> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001231>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011363> (<http://purl.obolibrary.org/obo/MP_0011363>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011363> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000074>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011422> (<http://purl.obolibrary.org/obo/MP_0011422>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000362>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011423> (<http://purl.obolibrary.org/obo/MP_0011423>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011423> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001225>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011698> (<http://purl.obolibrary.org/obo/MP_0011698>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011698> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001348>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011728> (<http://purl.obolibrary.org/obo/MP_0011728>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011728> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001905>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011781> (<http://purl.obolibrary.org/obo/MP_0011781>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011781> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002366>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011844> (<http://purl.obolibrary.org/obo/MP_0011844>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011844> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001232>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0011926> (<http://purl.obolibrary.org/obo/MP_0011926>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0011926> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000946>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0012006> (<http://purl.obolibrary.org/obo/MP_0012006>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0012006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002421>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0012018> (<http://purl.obolibrary.org/obo/MP_0012018>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0012018> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0003889>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0012020> (<http://purl.obolibrary.org/obo/MP_0012020>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0012020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001997>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0012028> (<http://purl.obolibrary.org/obo/MP_0012028>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0012028> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0004877>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0012506> (<http://purl.obolibrary.org/obo/MP_0012506>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0012506> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000955>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0012507> (<http://purl.obolibrary.org/obo/MP_0012507>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0012507> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001891>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0012508> (<http://purl.obolibrary.org/obo/MP_0012508>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0012508> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001890>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013295> (<http://purl.obolibrary.org/obo/MP_0013295>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013295> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001264>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013300> (<http://purl.obolibrary.org/obo/MP_0013300>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013300> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001736>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013319> (<http://purl.obolibrary.org/obo/MP_0013319>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013319> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000998>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013326> (<http://purl.obolibrary.org/obo/MP_0013326>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013326> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0005398>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013327> (<http://purl.obolibrary.org/obo/MP_0013327>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013327> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0005399>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013366> (<http://purl.obolibrary.org/obo/MP_0013366>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013366> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002369>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013368> (<http://purl.obolibrary.org/obo/MP_0013368>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013368> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001820>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013391> (<http://purl.obolibrary.org/obo/MP_0013391>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013391> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001818>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013450> (<http://purl.obolibrary.org/obo/MP_0013450>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013450> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001750>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013455> (<http://purl.obolibrary.org/obo/MP_0013455>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013455> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001817>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013532> (<http://purl.obolibrary.org/obo/MP_0013532>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013532> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001831>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013534> (<http://purl.obolibrary.org/obo/MP_0013534>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013534> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001829>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013535> (<http://purl.obolibrary.org/obo/MP_0013535>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013535> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001830>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013536> (<http://purl.obolibrary.org/obo/MP_0013536>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013536> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001832>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013555> (<http://purl.obolibrary.org/obo/MP_0013555>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013555> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0008974>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013556> (<http://purl.obolibrary.org/obo/MP_0013556>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013556> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0012344>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013557> (<http://purl.obolibrary.org/obo/MP_0013557>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013557> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0010243>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013559> (<http://purl.obolibrary.org/obo/MP_0013559>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013559> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002365>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013561> (<http://purl.obolibrary.org/obo/MP_0013561>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013561> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002368>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013567> (<http://purl.obolibrary.org/obo/MP_0013567>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013567> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000325>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013570> (<http://purl.obolibrary.org/obo/MP_0013570>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013570> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0010133>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013585> (<http://purl.obolibrary.org/obo/MP_0013585>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013585> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002123>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013586> (<http://purl.obolibrary.org/obo/MP_0013586>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002124>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013596> (<http://purl.obolibrary.org/obo/MP_0013596>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013596> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002255>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0013902> (<http://purl.obolibrary.org/obo/MP_0013902>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0013902> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000998>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0014030> (<http://purl.obolibrary.org/obo/MP_0014030>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0014030> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000414>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0014031> (<http://purl.obolibrary.org/obo/MP_0014031>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0014031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0011148>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0014047> (<http://purl.obolibrary.org/obo/MP_0014047>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0014047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001962>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0014078> (<http://purl.obolibrary.org/obo/MP_0014078>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0014078> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001213>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0014184> (<http://purl.obolibrary.org/obo/MP_0014184>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0014184> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002028>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0014185> (<http://purl.obolibrary.org/obo/MP_0014185>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0014185> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0002037>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0014190> (<http://purl.obolibrary.org/obo/MP_0014190>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0014190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001301>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0014200> (<http://purl.obolibrary.org/obo/MP_0014200>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0014200> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0004802>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0014201> (<http://purl.obolibrary.org/obo/MP_0014201>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0014201> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001277>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0020371> (<http://purl.obolibrary.org/obo/MP_0020371>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0020371> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0036145>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0020412> (<http://purl.obolibrary.org/obo/MP_0020412>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0020412> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000305>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0020517> (<http://purl.obolibrary.org/obo/MP_0020517>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0020517> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0008852>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0020860> (<http://purl.obolibrary.org/obo/MP_0020860>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0020860> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000964>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0030140> (<http://purl.obolibrary.org/obo/MP_0030140>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0030140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001577>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0030144> (<http://purl.obolibrary.org/obo/MP_0030144>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0030144> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0001577>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0030466> (<http://purl.obolibrary.org/obo/MP_0030466>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0030466> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0004103>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0030584> (<http://purl.obolibrary.org/obo/MP_0030584>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0030584> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000014>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
+# Class: <http://purl.obolibrary.org/obo/MP_0030802> (<http://purl.obolibrary.org/obo/MP_0030802>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/MP_0030802> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0001509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/UBERON_0000043>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002573> <http://purl.obolibrary.org/obo/PATO_0000460>))))
+
 
 )


### PR DESCRIPTION
This pull request:

- removes 153 EQs from mp-edit.owl
- adds 153 EQs through src/ontology/definitions.owl
- adds the reference from mp-edit.owl to the definitions.owl so you can see the EQs

For example you can look at http://purl.obolibrary.org/obo/MP_0000249 in Protege; the EQ is not anymore in the text file mp-edit.owl; but it shows up in protege, because it is in definitions.owl.

This PR further adds some functionality to delete patternised EQs from the edit file as soon as they appear in definitions.owl; but this must be manually triggered and I would like to do that for now to monitor that everything goes right.

Let me know if you have any more questions!