### PR TITLE
Replace chebi slim URL

### DIFF
--- a/src/ontology/mp-odk.yaml
+++ b/src/ontology/mp-odk.yaml
@@ -33,7 +33,7 @@ import_group:
     - id: uberon 
     - id: ro
     - id: chebi
-      mirror_from: https://raw.githubusercontent.com/obophenotype/chebi_obo_slim/main/chebi_slim.owl
+      mirror_from: http://purl.obolibrary.org/obo/upheno/chebi_slim.owl
     - id: pato
       make_base: true
     - id: cl


### PR DESCRIPTION
Replace https://raw.githubusercontent.com/obophenotype/chebi_obo_slim/main/chebi_slim.owl with http://purl.obolibrary.org/obo/upheno/chebi_slim.owl in mp-odk.yml
Update the repo did not change the makefile

CC @matentzn